### PR TITLE
current-non-scribble-entity-handler

### DIFF
--- a/markdown/parse.rkt
+++ b/markdown/parse.rkt
@@ -394,7 +394,7 @@
 
 (define $smart-ellipses
   (<?> (pdo (oneOfStrings "..." " . . . " ". . ." " . . .")
-            (return (current-non-scribble-entity-handler 'hellip)))
+            (return ((current-non-scribble-entity-handler) 'hellip)))
        "ellipsis"))
 
 (define $smart-punctuation


### PR DESCRIPTION
Currently the markdown parser converts "..." (and friends) to an `'hellip` symbol. This works lovely for `xexpr->html`, but `'hellip` isn't a supported `pre-content` symbol.

The parameter: `current-non-scribble-entity-handler` is called when `'hellip` is generated, and is a hook to substitute other "representations" of "...". It defaults to `values`, which leaves the output as the current parser does. It could, equally be:

``` racket
(match-lambda ['hellip "..."]) ; literally three dot string
(match-lambda ['hellip "…"]) ; U+2606 - HORIZONTAL ELLIPSIS = three dot leader
```

this handler can be used to extend any other "smart" symbol mappings.
