### PR TITLE
Don't escape inside scripts

### DIFF
--- a/markdown/display-xexpr.rkt
+++ b/markdown/display-xexpr.rkt
@@ -17,10 +17,12 @@
 ;; much. This is the warm bowl of porridge.
 
 (define current-pre (make-parameter 0))
+(define current-script (make-parameter #f))
 
 (define (display-xexpr x [indent 0])
   (define escape-entity-table    #rx"[<>&]")
   (define escape-attribute-table #rx"[<>&\"]")
+  (define escape-script-table #rx"[\"]")
   (define (replace-escaped s)
     (case (string-ref s 0)
       [(#\<) "&lt;"]
@@ -32,6 +34,8 @@
   (define (f tag ks vs body)
     (when (eq? tag 'pre)
       (current-pre (add1 (current-pre))))
+    (when (eq? tag 'script)
+      (current-script #t))
     (define-values (newline-str indent-str)
       (cond [(> (current-pre) 1) (values "" "")]
             [(memq tag '(a code em img span strong sup)) (values "" "")]
@@ -46,14 +50,16 @@
                   (display-xexpr b (+ 1 indent)))
                 (printf "</~a>" tag)])
     (when (eq? tag 'pre)
-      (current-pre (sub1 (current-pre)))))
+      (current-pre (sub1 (current-pre))))
+    (when (eq? tag 'script)
+      (current-script #f)))
   (match x
     [`(!HTML-COMMENT () ,x) (~> (format "<!--~a-->" x) display)]
     [`(,(? symbol? tag) ([,ks ,vs] ...) . ,els) (f tag ks vs els)]
     [`(,(? symbol? tag) . ,els) (f tag '() '() els)]
     [(? symbol? x) (~> (format "&~a;" x) display)]
     [(? integer? x) (~> (format "&#~a;" x) display)]
-    [_ (~> x ~a (escape escape-entity-table) display)]))
+    [_ (~> x ~a (escape (if (current-script) escape-script-table escape-entity-table)) display)]))
 
 (define (void-element? x)
   ;; Note: I'm not using Racket xml collection's


### PR DESCRIPTION
Adds a quick hacks that prevents escaping inside a `<script>` tag. This addresses greghendershott/frog#183, although is probably not correct in general.