### PR TITLE
MathJax changes to support MathJax 3

### DIFF
--- a/markdown/markdown.scrbl
+++ b/markdown/markdown.scrbl
@@ -204,8 +204,7 @@ Markdown Extra} and
 
 @item{Support for math-jax expressions --- inline within @litchar{\\(}
 and @litchar{\\)} delimiters and display within @litchar{\\[} and
-@litchar{\\]} delimiters --- resulting in @tt{script} elements with
-@tt{type=math/tex}.}
+@litchar{\\]} delimiters --- resulting in eqivalent markup in the output.}
 
 ]}
 

--- a/markdown/parse.rkt
+++ b/markdown/parse.rkt
@@ -640,14 +640,12 @@
 (define $math-jax-inline
   (try (pdo (string "\\\\(")
             (xs <- (many1Till $anyChar (try (string "\\\\)"))))
-            (return `(script ([type "math/tex"])
-                             ,(list->string xs))))))
+            (return (string-append "\\(" (list->string xs) "\\)")))))
 
 (define $math-jax-display
   (try (pdo (string "\\\\[")
             (xs <- (many1Till $anyChar (try (string "\\\\]"))))
-            (return `(script ([type "math/tex; mode=display"])
-                             ,(list->string xs))))))
+            (return (string-append "\\[" (list->string xs) "\\]")))))
 
 (define $math-jax
   (<or> $math-jax-inline

--- a/markdown/test.rkt
+++ b/markdown/test.rkt
@@ -933,11 +933,9 @@
                       (!HTML-COMMENT () " more")))))
   ;; https://github.com/greghendershott/markdown/issues/52
   (check-md "\\\\(ax^2 + bx + c = 0\\\\)"
-            '((p () (script ((type "math/tex"))
-                            "ax^2 + bx + c = 0"))))
+            '((p () "\\(ax^2 + bx + c = 0\\)")))
   (check-md "\\\\[ax^2 + bx + c = 0\\\\]"
-            '((p () (script ((type "math/tex; mode=display"))
-                            "ax^2 + bx + c = 0"))))
+            '((p () "\\[ax^2 + bx + c = 0\\]")))
   ;; but single \ still escapes as usual and the contents are still
   ;; parsed as markdown:
   (check-md "\\(some *italic* text\\)"


### PR DESCRIPTION
This changes the way that MathJax is generated to make things work with MathJax 3  This is the second PR associated with greghendershott/frog#252

Rather than generating script tags, this now simply wraps suitable delimiters around the maths, which MathJax will then find.  This is essentially because I could not work out how to make the script tags work with MathJax 3.

In fact I can't work out how the script tags *ever* worked: there doesn't seem to be any mention of embedding maths this way even for MathJax 2: all the focus is on using delimiters which MathJax looks for. So this would seem to make things a lot closer to how the MathJax people expect things to work, which think is a good thing.

In both MathJax 2 and 3 this makes the output look better: using the script approach seems to result in maths which, unless you apply additional styling, is blue, while this approach results in maths which is just ordinary.

This change

- only changes the output when using MathJax;
- makes the output simpler in that case;
- makes the formatted output better-looking I think;
- works with at least MathJax 2 as well as 3 (I've tested this).

I'm willing to handle any problems which result from this PR.