### PR TITLE
Force promises in footnotes as well

### DIFF
--- a/markdown/parse.rkt
+++ b/markdown/parse.rkt
@@ -1011,6 +1011,15 @@
                 '((p () "hi")
                   (p () "there"))))
 
+(module+ test
+  ;; Check that all references really are resolved
+  (check-not-false (xexpr-element-list?
+               (parse-markdown "This footnote[^6]
+
+[^6]: has a [link][1] which used to cause trouble.
+[1]: https://nowhere.nowhere.nowhere/somewhere.html \"to somewhere\"
+"))))
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;

--- a/markdown/parse.rkt
+++ b/markdown/parse.rkt
@@ -111,8 +111,8 @@
                  [current-footnote-defs (make-hash)])
     (~>> (regexp-replace* #rx"\r" (string-append text "\n\n") "")
          parse-markdown*
-         resolve-refs
-         append-footnote-defs)))
+         append-footnote-defs
+         resolve-refs)))
 
 ;; Use this internally to recursively parse fragments of Markdown
 ;; within the document. Does NOT set parameters. Does not append "\n"


### PR DESCRIPTION
This is a possible fix to greghendershott/markdown#82: previously `resolve-refs` got called before footnotes were appended to the parsed results, now it gets called afterwards.  This means that any promises which are lurking in footnotes themselves get forced as well.

This certainly fixes the problem in my case, although I don't pretend to understand the code well enough to be completely sure it is safe in all cases.