### PR TITLE
Depend on sexp-diff-lib only

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -13,5 +13,5 @@
                      "rackunit-lib"
                      "redex-lib"
                      "scribble-doc"
-                     "sexp-diff"))
+                     "sexp-diff-lib"))
 (define test-omit-paths '("MarkdownTest_1.0.3" "test"))


### PR DESCRIPTION
sexp-diff is now split, so you can depend only on the library portion and not the docs and tests.