### PR TITLE
Fix leading spaces in multiline footnotes

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,5 +1,5 @@
 #lang info
-(define version "0.26")
+(define version "0.27")
 (define collection 'multi)
 (define deps '(["base" #:version "6.3"]
                ["parsack" #:version "0.4"]

--- a/markdown/parse.rkt
+++ b/markdown/parse.rkt
@@ -829,7 +829,7 @@
 
 (define $raw-lines
   (>>= (many1 $raw-line)
-       (compose1 return string-join)))
+       (compose1 return string-append*)))
 
 (define $reference-title
   ;; Not quite the same as $link-title. 1. Title may be grouped in

--- a/markdown/test.rkt
+++ b/markdown/test.rkt
@@ -171,7 +171,7 @@
                     (p () "The first paragraph of the definition.")
                     (p () "Paragraph two of the definition.")
                     (blockquote () (p () "A blockquote with multiple lines."))
-                    (pre () (code () "a code block\n here"))
+                    (pre () (code () "a code block\nhere"))
                     (p ()
                        "A final paragraph."
                        nbsp


### PR DESCRIPTION
This was just a minor oversight: `$raw-lines` used `string-join` instead of `string-append*`, which would cause additional spaces to be added before certain lines in multiline footnotes. This PR implements the obvious fix.